### PR TITLE
Introduce TypedInput

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -39,6 +39,11 @@
             </errorLevel>
         </MissingConstructor>
         <PossiblyUnusedMethod errorLevel="suppress"/>
+        <PossiblyUnusedReturnValue>
+            <errorLevel type="suppress">
+                <file name="src/IOGetters.php"/>
+            </errorLevel>
+        </PossiblyUnusedReturnValue>
         <UndefinedClass>
             <errorLevel type="suppress">
                 <file name="tests/Generator/ClassNameTest.php"/>

--- a/src/Generator/GetterGenerator.php
+++ b/src/Generator/GetterGenerator.php
@@ -33,7 +33,7 @@ final class GetterGenerator
      */
     public function __METHOD_NAME_PLACEHOLDER__(string $name): __PHP_RETURN_TYPE_PLACEHOLDER__
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
     
         $type = TypeFactory::createTypeFromClassNames([
         __TYPE_CLASS_NAMES_PLACEHOLDER__
@@ -49,7 +49,7 @@ final class GetterGenerator
      */
     public function __METHOD_NAME_PLACEHOLDER__(string $name): __PHP_RETURN_TYPE_PLACEHOLDER__
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
     
         $type = TypeFactory::createTypeFromClassNames([
         __TYPE_CLASS_NAMES_PLACEHOLDER__

--- a/src/IO.php
+++ b/src/IO.php
@@ -23,12 +23,17 @@ declare(strict_types=1);
 
 namespace Fidry\Console;
 
+use Fidry\Console\Input\TypedInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+/**
+ * @psalm-import-type ArgumentInput from \Fidry\Console\InputAssert
+ * @psalm-import-type OptionInput from \Fidry\Console\InputAssert
+ */
 final class IO extends SymfonyStyle
 {
     use IOGetters;
@@ -67,10 +72,24 @@ final class IO extends SymfonyStyle
         return $this->output;
     }
 
+    public function getArgument(string $name): TypedInput
+    {
+        return TypedInput::fromArgument(
+            $this->input->getArgument($name)
+        );
+    }
+
+    public function getOption(string $name): TypedInput
+    {
+        return TypedInput::fromOption(
+            $this->input->getOption($name)
+        );
+    }
+
     /**
      * @return null|string|list<string>
      */
-    private function getArgument(string $name)
+    private function getLegacyArgument(string $name)
     {
         $argument = $this->input->getArgument($name);
 
@@ -82,7 +101,7 @@ final class IO extends SymfonyStyle
     /**
      * @return null|bool|string|list<string>
      */
-    private function getOption(string $name)
+    private function getLegacyOption(string $name)
     {
         $option = $this->input->getOption($name);
 

--- a/src/IOGetters.php
+++ b/src/IOGetters.php
@@ -22,7 +22,7 @@ trait IOGetters
 {
     public function getBooleanArgument(string $name): bool
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\BooleanType::class,
@@ -33,7 +33,7 @@ trait IOGetters
 
     public function getNullableBooleanArgument(string $name): ?bool
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -45,7 +45,7 @@ trait IOGetters
 
     public function getStringArgument(string $name): string
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\StringType::class,
@@ -56,7 +56,7 @@ trait IOGetters
 
     public function getNullableStringArgument(string $name): ?string
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -71,7 +71,7 @@ trait IOGetters
      */
     public function getStringListArgument(string $name): array
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,
@@ -83,7 +83,7 @@ trait IOGetters
 
     public function getIntegerArgument(string $name): int
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\IntegerType::class,
@@ -94,7 +94,7 @@ trait IOGetters
 
     public function getNullableIntegerArgument(string $name): ?int
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -109,7 +109,7 @@ trait IOGetters
      */
     public function getIntegerListArgument(string $name): array
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,
@@ -121,7 +121,7 @@ trait IOGetters
 
     public function getFloatArgument(string $name): float
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\FloatType::class,
@@ -132,7 +132,7 @@ trait IOGetters
 
     public function getNullableFloatArgument(string $name): ?float
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -147,7 +147,7 @@ trait IOGetters
      */
     public function getFloatListArgument(string $name): array
     {
-        $argument = $this->getArgument($name);
+        $argument = $this->getLegacyArgument($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,
@@ -159,7 +159,7 @@ trait IOGetters
 
     public function getBooleanOption(string $name): bool
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\BooleanType::class,
@@ -170,7 +170,7 @@ trait IOGetters
 
     public function getNullableBooleanOption(string $name): ?bool
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -182,7 +182,7 @@ trait IOGetters
 
     public function getStringOption(string $name): string
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\StringType::class,
@@ -193,7 +193,7 @@ trait IOGetters
 
     public function getNullableStringOption(string $name): ?string
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -208,7 +208,7 @@ trait IOGetters
      */
     public function getStringListOption(string $name): array
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,
@@ -220,7 +220,7 @@ trait IOGetters
 
     public function getIntegerOption(string $name): int
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\IntegerType::class,
@@ -231,7 +231,7 @@ trait IOGetters
 
     public function getNullableIntegerOption(string $name): ?int
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -246,7 +246,7 @@ trait IOGetters
      */
     public function getIntegerListOption(string $name): array
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,
@@ -258,7 +258,7 @@ trait IOGetters
 
     public function getFloatOption(string $name): float
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\FloatType::class,
@@ -269,7 +269,7 @@ trait IOGetters
 
     public function getNullableFloatOption(string $name): ?float
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\NullableType::class,
@@ -284,7 +284,7 @@ trait IOGetters
      */
     public function getFloatListOption(string $name): array
     {
-        $option = $this->getOption($name);
+        $option = $this->getLegacyOption($name);
 
         $type = TypeFactory::createTypeFromClassNames([
             \Fidry\Console\Type\ListType::class,

--- a/src/Input/TypedInput.php
+++ b/src/Input/TypedInput.php
@@ -83,7 +83,7 @@ final class TypedInput
     /**
      * @return list<int>
      */
-    public function asIntList(): array
+    public function asIntegerList(): array
     {
         return (new ListType(new IntegerType()))->castValue($this->value);
     }

--- a/src/Input/TypedInput.php
+++ b/src/Input/TypedInput.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Input;
+
+use Fidry\Console\InputAssert;
+use Fidry\Console\Type\BooleanType;
+use Fidry\Console\Type\FloatType;
+use Fidry\Console\Type\IntegerType;
+use Fidry\Console\Type\ListType;
+use Fidry\Console\Type\NullableType;
+use Fidry\Console\Type\StringType;
+
+/**
+ * @psalm-import-type ArgumentInput from \Fidry\Console\InputAssert
+ * @psalm-import-type OptionInput from \Fidry\Console\InputAssert
+ */
+final class TypedInput
+{
+    /**
+     * @var ArgumentInput|OptionInput
+     */
+    private $value;
+
+    /**
+     * @param ArgumentInput|OptionInput $value
+     */
+    private function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param ArgumentInput $argument
+     */
+    public static function fromArgument($argument): self
+    {
+        InputAssert::assertIsValidArgumentType($argument);
+
+        return new self($argument);
+    }
+
+    /**
+     * @param OptionInput $option
+     */
+    public static function fromOption($option): self
+    {
+        InputAssert::assertIsValidOptionType($option);
+
+        return new self($option);
+    }
+
+    public function asBoolean(): bool
+    {
+        return (new BooleanType())->castValue($this->value);
+    }
+
+    public function asNullableBoolean(): ?bool
+    {
+        return (new NullableType(new BooleanType()))->castValue($this->value);
+    }
+
+    public function asInteger(): int
+    {
+        return (new IntegerType())->castValue($this->value);
+    }
+
+    public function asNullableInteger(): ?int
+    {
+        return (new NullableType(new IntegerType()))->castValue($this->value);
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function asIntList(): array
+    {
+        return (new ListType(new IntegerType()))->castValue($this->value);
+    }
+
+    public function asFloat(): float
+    {
+        return (new FloatType())->castValue($this->value);
+    }
+
+    public function asNullableFloat(): ?float
+    {
+        return (new NullableType(new FloatType()))->castValue($this->value);
+    }
+
+    /**
+     * @return list<float>
+     */
+    public function asFloatList(): array
+    {
+        return (new ListType(new FloatType()))->castValue($this->value);
+    }
+
+    public function asString(): string
+    {
+        return (new StringType())->castValue($this->value);
+    }
+
+    public function asNullableString(): ?string
+    {
+        return (new NullableType(new StringType()))->castValue($this->value);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function asStringList(): array
+    {
+        return (new ListType(new StringType()))->castValue($this->value);
+    }
+}

--- a/tests/Generator/GetterGeneratorTest.php
+++ b/tests/Generator/GetterGeneratorTest.php
@@ -48,7 +48,7 @@ final class GetterGeneratorTest extends TestCase
          */
         public function getBooleanOption(string $name): bool
         {
-            $option = $this->getOption($name);
+            $option = $this->getLegacyOption($name);
         
             $type = TypeFactory::createTypeFromClassNames([
                 \Fidry\Console\Type\BooleanType::class,
@@ -76,7 +76,7 @@ final class GetterGeneratorTest extends TestCase
              */
             public function getBooleanArgument(string $name): bool
             {
-                $argument = $this->getArgument($name);
+                $argument = $this->getLegacyArgument($name);
             
                 $type = TypeFactory::createTypeFromClassNames([
                     \Fidry\Console\Type\BooleanType::class,
@@ -97,7 +97,7 @@ final class GetterGeneratorTest extends TestCase
              */
             public function getNullableBooleanArgument(string $name): ?bool
             {
-                $argument = $this->getArgument($name);
+                $argument = $this->getLegacyArgument($name);
             
                 $type = TypeFactory::createTypeFromClassNames([
                     \Fidry\Console\Type\NullableType::class,
@@ -119,7 +119,7 @@ final class GetterGeneratorTest extends TestCase
              */
             public function getBooleanListArgument(string $name): array
             {
-                $argument = $this->getArgument($name);
+                $argument = $this->getLegacyArgument($name);
             
                 $type = TypeFactory::createTypeFromClassNames([
                     \Fidry\Console\Type\ListType::class,
@@ -143,7 +143,7 @@ final class GetterGeneratorTest extends TestCase
              */
             public function getNullableBooleanListArgument(string $name): ?array
             {
-                $argument = $this->getArgument($name);
+                $argument = $this->getLegacyArgument($name);
             
                 $type = TypeFactory::createTypeFromClassNames([
                     \Fidry\Console\Type\NullableType::class,
@@ -168,7 +168,7 @@ final class GetterGeneratorTest extends TestCase
              */
             public function getNullableBooleanListArgument(string $name): array
             {
-                $argument = $this->getArgument($name);
+                $argument = $this->getLegacyArgument($name);
             
                 $type = TypeFactory::createTypeFromClassNames([
                     \Fidry\Console\Type\ListType::class,

--- a/tests/Generator/GettersGeneratorTest.php
+++ b/tests/Generator/GettersGeneratorTest.php
@@ -75,7 +75,7 @@ final class GettersGeneratorTest extends TestCase
                  */
                 public function getStringArgument(string $name): string
                 {
-                    $argument = $this->getArgument($name);
+                    $argument = $this->getLegacyArgument($name);
 
                     $type = TypeFactory::createTypeFromClassNames([
                         \Fidry\Console\Type\StringType::class,
@@ -89,7 +89,7 @@ final class GettersGeneratorTest extends TestCase
                  */
                 public function getBooleanArgument(string $name): bool
                 {
-                    $argument = $this->getArgument($name);
+                    $argument = $this->getLegacyArgument($name);
             
                     $type = TypeFactory::createTypeFromClassNames([
                         \Fidry\Console\Type\BooleanType::class,

--- a/tests/IO/TypeAssertions.php
+++ b/tests/IO/TypeAssertions.php
@@ -31,47 +31,47 @@ final class TypeAssertions
     ): void {
         self::assertExpectedType(
             $expected->boolean,
-            static fn () => $io->getBooleanArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asBoolean(),
         );
         self::assertExpectedType(
             $expected->nullableBoolean,
-            static fn () => $io->getNullableBooleanArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asNullableBoolean(),
         );
         self::assertExpectedType(
             $expected->string,
-            static fn () => $io->getStringArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asString(),
         );
         self::assertExpectedType(
             $expected->nullableString,
-            static fn () => $io->getNullableStringArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asNullableString(),
         );
         self::assertExpectedType(
             $expected->stringArray,
-            static fn () => $io->getStringListArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asStringList(),
         );
         self::assertExpectedType(
             $expected->integer,
-            static fn () => $io->getIntegerArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asInteger(),
         );
         self::assertExpectedType(
             $expected->nullableInteger,
-            static fn () => $io->getNullableIntegerArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asNullableInteger(),
         );
         self::assertExpectedType(
             $expected->integerArray,
-            static fn () => $io->getIntegerListArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asIntegerList(),
         );
         self::assertExpectedType(
             $expected->float,
-            static fn () => $io->getFloatArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asFloat(),
         );
         self::assertExpectedType(
             $expected->nullableFloat,
-            static fn () => $io->getNullableFloatArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asNullableFloat(),
         );
         self::assertExpectedType(
             $expected->floatArray,
-            static fn () => $io->getFloatListArgument($argumentName),
+            static fn () => $io->getArgument($argumentName)->asFloatList(),
         );
     }
 
@@ -82,47 +82,47 @@ final class TypeAssertions
     ): void {
         self::assertExpectedType(
             $expected->boolean,
-            static fn () => $io->getBooleanOption($optionName),
+            static fn () => $io->getOption($optionName)->asBoolean(),
         );
         self::assertExpectedType(
             $expected->nullableBoolean,
-            static fn () => $io->getNullableBooleanOption($optionName),
+            static fn () => $io->getOption($optionName)->asNullableBoolean(),
         );
         self::assertExpectedType(
             $expected->string,
-            static fn () => $io->getStringOption($optionName),
+            static fn () => $io->getOption($optionName)->asString(),
         );
         self::assertExpectedType(
             $expected->nullableString,
-            static fn () => $io->getNullableStringOption($optionName),
+            static fn () => $io->getOption($optionName)->asNullableString(),
         );
         self::assertExpectedType(
             $expected->stringArray,
-            static fn () => $io->getStringListOption($optionName),
+            static fn () => $io->getOption($optionName)->asStringList(),
         );
         self::assertExpectedType(
             $expected->integer,
-            static fn () => $io->getIntegerOption($optionName),
+            static fn () => $io->getOption($optionName)->asInteger(),
         );
         self::assertExpectedType(
             $expected->nullableInteger,
-            static fn () => $io->getNullableIntegerOption($optionName),
+            static fn () => $io->getOption($optionName)->asNullableInteger(),
         );
         self::assertExpectedType(
             $expected->integerArray,
-            static fn () => $io->getIntegerListOption($optionName),
+            static fn () => $io->getOption($optionName)->asIntegerList(),
         );
         self::assertExpectedType(
             $expected->float,
-            static fn () => $io->getFloatOption($optionName),
+            static fn () => $io->getOption($optionName)->asFloat(),
         );
         self::assertExpectedType(
             $expected->nullableFloat,
-            static fn () => $io->getNullableFloatOption($optionName),
+            static fn () => $io->getOption($optionName)->asNullableFloat(),
         );
         self::assertExpectedType(
             $expected->floatArray,
-            static fn () => $io->getFloatListOption($optionName),
+            static fn () => $io->getOption($optionName)->asFloatList(),
         );
     }
 


### PR DESCRIPTION
Introduce `TypedInput` which wraps the argument/option value and offers the typed API.

I believe it will be better to introduce more changes and a richer API via this pattern rather than generating completely `IOGetters`.
