### PR TITLE
Bump dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4.0",
-        "symfony/console": "^5.3 || ^6.1",
+        "php": "^7.4.0 || ^8.0.0",
+        "symfony/console": "^5.4 || ^6.1",
         "symfony/event-dispatcher-contracts": "^2.4",
         "symfony/service-contracts": "^v2.4.0",
         "thecodingmachine/safe": "^1.3",
@@ -25,12 +25,12 @@
         "infection/infection": "^0.26",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.3",
-        "symfony/dependency-injection": "^5.3 || ^6.1",
-        "symfony/framework-bundle": "^5.3 || ^6.1",
-        "symfony/http-kernel": "^5.3 || ^6.1",
-        "symfony/phpunit-bridge": "^5.3 || ^6.0",
-        "symfony/yaml": "^3.4.47 || ^4.4.19 || ^5.1.11 || ^5.3 || ^6.1",
-        "webmozarts/strict-phpunit": "^7.0@beta"
+        "symfony/dependency-injection": "^5.4 || ^6.1",
+        "symfony/framework-bundle": "^5.4 || ^6.1",
+        "symfony/http-kernel": "^5.4 || ^6.1",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/yaml": "^5.4 || ^6.1",
+        "webmozarts/strict-phpunit": "^7.3"
     },
     "conflict": {
         "symfony/dependency-injection": "<5.3.0",

--- a/src/InputAssert.php
+++ b/src/InputAssert.php
@@ -25,7 +25,8 @@ use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException as AssertInvalidArgumentException;
 
 /**
- * TODO: move this under Internal
+ * TODO: move this under Internal.
+ *
  * @private
  * @psalm-type ArgumentInput = null|string|list<string>
  * @psalm-type OptionInput = null|bool|string|list<string>


### PR DESCRIPTION
- Bump min Symfony 5.x version to 5.4
- Remove support for Symfony >5.4 for Symfony YAML
- Switch to a strict version of Webmozarts StrictPHPUnit