### PR TITLE
Disable covers-validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,9 @@ validate-package: vendor
 .PHONY: covers-validator
 covers-validator: ## Validates the PHPUnit @covers annotations
 covers-validator: $(COVERS_VALIDATOR_BIN) vendor
-ifndef SKIP_COVERS_VALIDATOR
-	$(COVERS_VALIDATOR)
-endif
+#ifndef SKIP_COVERS_VALIDATOR
+#	$(COVERS_VALIDATOR)
+#endif
 
 
 .PHONY: phpunit


### PR DESCRIPTION
CoversValidator is currently not Symfony6 compatible. Waiting on https://github.com/oradwell/covers-validator/pull/41