### PR TITLE
refactor: Review the DecoratesInput implementation

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,8 +6,7 @@
             "src"
         ],
         "excludes": [
-            "src/Input/DecoratesInputSymfony5.php",
-            "src/Input/DecoratesInputSymfony6.php"
+            "src/Input/Compatibility"
         ]
     },
     "logs": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,12 +25,9 @@
         <directory name="tests"/>
 
         <ignoreFiles>
+            <directory name="src/Input/Compatibility"/>
             <file name="src/Input/DecoratesInput.php"/>
-            <file name="src/Input/DecoratesInputSymfony5.php"/>
-            <file name="src/Input/DecoratesInputSymfony6.php"/>
             <file name="src/Input/StyledOutput.php"/>
-            <file name="src/Input/StyledOutputSymfony5.php"/>
-            <file name="src/Input/StyledOutputSymfony6.php"/>
             <directory name="vendor"/>
             <directory name="tests/Integration/var"/>
             <file name="tests/Internal/Type/ConfigurableType.php"/>

--- a/src/Input/Compatibility/DecoratesInputSymfony5.php
+++ b/src/Input/Compatibility/DecoratesInputSymfony5.php
@@ -21,13 +21,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Input\Compatibility;
 
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use function func_get_args;
 
 /**
+ * @internal
  * @psalm-require-implements InputInterface
  */
 trait DecoratesInputSymfony5
@@ -97,9 +98,6 @@ trait DecoratesInputSymfony5
         return $this->input->getOption(...func_get_args());
     }
 
-    /**
-     * @param non-empty-string $name
-     */
     public function hasOption(string $name, bool $onlyRealParams = false): bool
     {
         return $this->input->hasOption(...func_get_args());

--- a/src/Input/Compatibility/DecoratesInputSymfony6.php
+++ b/src/Input/Compatibility/DecoratesInputSymfony6.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Input\Compatibility;
 
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,6 +29,7 @@ use function func_get_args;
 
 /**
  * @internal
+ * @psalm-require-implements InputInterface
  */
 trait DecoratesInputSymfony6
 {
@@ -67,7 +68,6 @@ trait DecoratesInputSymfony6
         return $this->input->validate();
     }
 
-    /** @psalm-suppress LessSpecificImplementedReturnType */
     public function getArguments(): array
     {
         return $this->input->getArguments();
@@ -83,7 +83,6 @@ trait DecoratesInputSymfony6
         return $this->input->hasArgument(...func_get_args());
     }
 
-    /** @psalm-suppress LessSpecificImplementedReturnType */
     public function getOptions(): array
     {
         return $this->input->getOptions();

--- a/src/Input/Compatibility/StyledOutputSymfony5.php
+++ b/src/Input/Compatibility/StyledOutputSymfony5.php
@@ -11,14 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Input\Compatibility;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\StyleInterface;
-use function key;
 
 /**
  * Complements the Symfony Style interface with the methods present in

--- a/src/Input/Compatibility/StyledOutputSymfony6.php
+++ b/src/Input/Compatibility/StyledOutputSymfony6.php
@@ -11,14 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Input\Compatibility;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\StyleInterface;
-use function key;
 
 /**
  * Complements the Symfony Style interface with the methods present in

--- a/src/Input/DecoratesInput.php
+++ b/src/Input/DecoratesInput.php
@@ -14,9 +14,15 @@ declare(strict_types=1);
 namespace Fidry\Console\Input;
 
 use Composer\InstalledVersions;
+use Fidry\Console\Input\Compatibility\DecoratesInputSymfony5;
+use Fidry\Console\Input\Compatibility\DecoratesInputSymfony6;
 use function Safe\class_alias;
 use function version_compare;
 
+// This is purely for the compatibility layer between Symfony5 & Symfony6. The
+// behaviour is the same, only the method signatures differ.
+// To have a more comprehensive look of the class check:
+// stubs/DecoratesInput.php
 class_alias(
     (string) version_compare(
         (string) InstalledVersions::getPrettyVersion('symfony/console'),

--- a/src/Input/StyledOutput.php
+++ b/src/Input/StyledOutput.php
@@ -14,9 +14,15 @@ declare(strict_types=1);
 namespace Fidry\Console\Input;
 
 use Composer\InstalledVersions;
+use Fidry\Console\Input\Compatibility\StyledOutputSymfony5;
+use Fidry\Console\Input\Compatibility\StyledOutputSymfony6;
 use function Safe\class_alias;
 use function version_compare;
 
+// This is purely for the compatibility layer between Symfony5 & Symfony6. The
+// behaviour is the same, only the method signatures differ.
+// To have a more comprehensive look of the class check:
+// stubs/StyledOutput.php
 class_alias(
     (string) version_compare(
         (string) InstalledVersions::getPrettyVersion('symfony/console'),

--- a/stubs/DecoratesInput.php
+++ b/stubs/DecoratesInput.php
@@ -29,6 +29,7 @@ use function func_get_args;
 
 /**
  * @internal
+ * @psalm-require-implements InputInterface
  */
 trait DecoratesInput
 {


### PR DESCRIPTION
- Move the compatibility layer to a dedicated internal namespace
- Add a few more comments and fix unnecessary PHPDoc