### PR TITLE
refactor: Re-organise the IO related namespaces

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,21 +1,7 @@
-!/dist/.gitkeep
-/.composer-cache/
-/.env.*.local
-/.env.local
-/.env.local.php
-/.idea/
-/.php-cs-fixer.cache
-/.phpunit.result.cache
-/.psalm/
-/composer.lock
-/config/secrets/prod/prod.decrypt.private.php
-/dist/
-/infection.log
-/lsp/
-/phpunit.xml
-/public/bundles/
-/tests/Integration/var/cache/
-/tests/Integration/var/logs/
-/var/
-/vendor-bin/*/vendor/
-/vendor/
+.github export-ignore
+.makefile export-ignore
+bin export-ignore
+doc export-ignore
+stubs export-ignore
+tests export-ignore
+vendor-bin export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,21 @@
-# Not archived
-.github export-ignore
-.makefile export-ignore
-bin export-ignore
-doc export-ignore
-tests export-ignore
-vendor-bin export-ignore
-stubs export-ignore
+!/dist/.gitkeep
+/.composer-cache/
+/.env.*.local
+/.env.local
+/.env.local.php
+/.idea/
+/.php-cs-fixer.cache
+/.phpunit.result.cache
+/.psalm/
+/composer.lock
+/config/secrets/prod/prod.decrypt.private.php
+/dist/
+/infection.log
+/lsp/
+/phpunit.xml
+/public/bundles/
+/tests/Integration/var/cache/
+/tests/Integration/var/logs/
+/var/
+/vendor-bin/*/vendor/
+/vendor/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
+# Not archived
 .github export-ignore
 .makefile export-ignore
 bin export-ignore
 doc export-ignore
-stubs export-ignore
 tests export-ignore
 vendor-bin export-ignore
+stubs export-ignore

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ composer_normalize_lint: vendor
 
 .PHONY: gitignore_sort
 gitignore_sort:
-	LC_ALL=C sort -u .gitignore -o .gitattributes
+	LC_ALL=C sort -u .gitignore -o .gitignore
+	LC_ALL=C sort -u .gitattributes -o .gitattributes
 
 .PHONY: php_cs_fixer
 php_cs_fixer: $(PHP_CS_FIXER_BIN)

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ composer_normalize_lint: vendor
 
 .PHONY: gitignore_sort
 gitignore_sort:
-	LC_ALL=C sort -u .gitignore -o .gitignore
+	LC_ALL=C sort -u .gitignore -o .gitattributes
 
 .PHONY: php_cs_fixer
 php_cs_fixer: $(PHP_CS_FIXER_BIN)

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ composer_normalize_lint: vendor
 .PHONY: gitignore_sort
 gitignore_sort:
 	LC_ALL=C sort -u .gitignore -o .gitignore
-	LC_ALL=C sort -u .gitattributes -o .gitattributes
 
 .PHONY: php_cs_fixer
 php_cs_fixer: $(PHP_CS_FIXER_BIN)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ follows:
 namespace Acme;
 
 use Acme\MyService;
-use Fidry\Console\{ Command\Command, Command\Configuration, ExitCode, Input\IO };
+use Fidry\Console\{ Command\Command, Command\Configuration, ExitCode, IO };
 use Symfony\Component\Console\Input\InputArgument;
 
 final class CommandWithService implements Command

--- a/doc/call-other-commands.md
+++ b/doc/call-other-commands.md
@@ -24,7 +24,7 @@ namespace App\Console\Command;
 use Fidry\Console\Command\CommandAware;
 use Fidry\Console\Command\CommandAwareness;
 use Fidry\Console\Command\Command;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Input\ArrayInput;
 
 final class CreateUserCommand implements Command, CommandAware

--- a/doc/command.md
+++ b/doc/command.md
@@ -28,7 +28,7 @@ namespace App\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 final class CreateUserCommand implements Command
 {
@@ -69,7 +69,7 @@ You can optionally define a description, help message and the input options and 
 // src/Command/CreateUserCommand.php
 namespace App\Command;
 
-use Fidry\Console\Command\Command;use Fidry\Console\Command\Configuration;use Fidry\Console\Input\IO;use Symfony\Component\Console\Input\InputArgument;
+use Fidry\Console\Command\Command;use Fidry\Console\Command\Configuration;use Fidry\Console\IO;use Symfony\Component\Console\Input\InputArgument;
 
 final class CreateUserCommand implements Command
 {
@@ -268,7 +268,7 @@ use App\Service\UserManager;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 final class CreateUserCommand implements Command
 {

--- a/psalm.xml
+++ b/psalm.xml
@@ -28,10 +28,11 @@
 
         <ignoreFiles>
             <directory name="src/Input/Compatibility"/>
+            <directory name="src/Output/Compatibility"/>
             <file name="src/Input/DecoratesInput.php"/>
-            <file name="src/Input/DecoratesOutput.php"/>
-            <file name="src/Input/DecoratesStyledOutput.php"/>
-            <file name="src/Input/StyledOutput.php"/>
+            <file name="src/Output/DecoratesOutput.php"/>
+            <file name="src/Output/DecoratesStyledOutput.php"/>
+            <file name="src/Output/StyledOutput.php"/>
             <directory name="vendor"/>
             <directory name="tests/Integration/var"/>
             <file name="tests/Internal/Type/ConfigurableType.php"/>

--- a/src/Application/ApplicationRunner.php
+++ b/src/Application/ApplicationRunner.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Application;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/src/Application/ConfigurableIO.php
+++ b/src/Application/ConfigurableIO.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Application;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 interface ConfigurableIO
 {

--- a/src/Application/SymfonyApplication.php
+++ b/src/Application/SymfonyApplication.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Application;
 use Fidry\Console\Command\Command as FidryCommand;
 use Fidry\Console\Command\LazyCommand as FidryLazyCommand;
 use Fidry\Console\Command\SymfonyCommand;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use LogicException;
 use Symfony\Component\Console\Application as BaseSymfonyApplication;
 use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Command;
 
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 interface Command
 {

--- a/src/Command/InitializableCommand.php
+++ b/src/Command/InitializableCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Command;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 interface InitializableCommand extends Command
 {

--- a/src/Command/InteractiveCommand.php
+++ b/src/Command/InteractiveCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Command;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 interface InteractiveCommand extends Command
 {

--- a/src/Command/ReversedSymfonyCommand.php
+++ b/src/Command/ReversedSymfonyCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Command;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 /**

--- a/src/Command/SymfonyCommand.php
+++ b/src/Command/SymfonyCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Command;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Helper/QuestionHelper.php
+++ b/src/Helper/QuestionHelper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Helper;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper as SymfonyQuestionHelper;
 use Symfony\Component\Console\Question\Question;

--- a/src/IO.php
+++ b/src/IO.php
@@ -21,9 +21,15 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console;
 
 use Closure;
+use Fidry\Console\Input\DecoratesInput;
+use Fidry\Console\Input\TypedInput;
+use Fidry\Console\Output\DecoratesOutput;
+use Fidry\Console\Output\DecoratesStyledOutput;
+use Fidry\Console\Output\StyledOutput;
+use Fidry\Console\Output\SymfonyStyledOutput;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;

--- a/src/Output/Compatibility/DecoratesOutputSymfony5.php
+++ b/src/Output/Compatibility/DecoratesOutputSymfony5.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Output/Compatibility/DecoratesOutputSymfony6.php
+++ b/src/Output/Compatibility/DecoratesOutputSymfony6.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Output/Compatibility/DecoratesStyledOutputSymfony5.php
+++ b/src/Output/Compatibility/DecoratesStyledOutputSymfony5.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
-use Fidry\Console\Input\StyledOutput;
+use Fidry\Console\Output\StyledOutput;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\Question;
 use function func_get_args;

--- a/src/Output/Compatibility/DecoratesStyledOutputSymfony6.php
+++ b/src/Output/Compatibility/DecoratesStyledOutputSymfony6.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
-use Fidry\Console\Input\StyledOutput;
+use Fidry\Console\Output\StyledOutput;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;

--- a/src/Output/Compatibility/StyledOutputSymfony5.php
+++ b/src/Output/Compatibility/StyledOutputSymfony5.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;

--- a/src/Output/Compatibility/StyledOutputSymfony6.php
+++ b/src/Output/Compatibility/StyledOutputSymfony6.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input\Compatibility;
+namespace Fidry\Console\Output\Compatibility;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;

--- a/src/Output/DecoratesOutput.php
+++ b/src/Output/DecoratesOutput.php
@@ -11,25 +11,21 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Composer\InstalledVersions;
-use Fidry\Console\Input\Compatibility\StyledOutputSymfony5;
-use Fidry\Console\Input\Compatibility\StyledOutputSymfony6;
+use Fidry\Console\Output\Compatibility\DecoratesOutputSymfony5;
+use Fidry\Console\Output\Compatibility\DecoratesOutputSymfony6;
 use function Safe\class_alias;
 use function version_compare;
 
-// This is purely for the compatibility layer between Symfony5 & Symfony6. The
-// behaviour is the same, only the method signatures differ.
-// To have a more comprehensive look of the class check:
-// stubs/StyledOutput.php
 class_alias(
     (string) version_compare(
         (string) InstalledVersions::getPrettyVersion('symfony/console'),
         'v6.0',
         '>=',
     )
-        ? StyledOutputSymfony6::class
-        : StyledOutputSymfony5::class,
-    \Fidry\Console\Input\StyledOutput::class,
+        ? DecoratesOutputSymfony6::class
+        : DecoratesOutputSymfony5::class,
+    \Fidry\Console\Output\DecoratesOutput::class,
 );

--- a/src/Output/DecoratesStyledOutput.php
+++ b/src/Output/DecoratesStyledOutput.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Composer\InstalledVersions;
-use Fidry\Console\Input\Compatibility\DecoratesStyledOutputSymfony5;
-use Fidry\Console\Input\Compatibility\DecoratesStyledOutputSymfony6;
+use Fidry\Console\Output\Compatibility\DecoratesStyledOutputSymfony5;
+use Fidry\Console\Output\Compatibility\DecoratesStyledOutputSymfony6;
 use function Safe\class_alias;
 use function version_compare;
 
@@ -27,5 +27,5 @@ class_alias(
     )
         ? DecoratesStyledOutputSymfony6::class
         : DecoratesStyledOutputSymfony5::class,
-    \Fidry\Console\Input\DecoratesStyledOutput::class,
+    \Fidry\Console\Output\DecoratesStyledOutput::class,
 );

--- a/src/Output/StyledOutput.php
+++ b/src/Output/StyledOutput.php
@@ -11,21 +11,25 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Composer\InstalledVersions;
-use Fidry\Console\Input\Compatibility\DecoratesOutputSymfony5;
-use Fidry\Console\Input\Compatibility\DecoratesOutputSymfony6;
+use Fidry\Console\Output\Compatibility\StyledOutputSymfony5;
+use Fidry\Console\Output\Compatibility\StyledOutputSymfony6;
 use function Safe\class_alias;
 use function version_compare;
 
+// This is purely for the compatibility layer between Symfony5 & Symfony6. The
+// behaviour is the same, only the method signatures differ.
+// To have a more comprehensive look of the class check:
+// stubs/StyledOutput.php
 class_alias(
     (string) version_compare(
         (string) InstalledVersions::getPrettyVersion('symfony/console'),
         'v6.0',
         '>=',
     )
-        ? DecoratesOutputSymfony6::class
-        : DecoratesOutputSymfony5::class,
-    \Fidry\Console\Input\DecoratesOutput::class,
+        ? StyledOutputSymfony6::class
+        : StyledOutputSymfony5::class,
+    \Fidry\Console\Output\StyledOutput::class,
 );

--- a/src/Output/SymfonyStyledOutput.php
+++ b/src/Output/SymfonyStyledOutput.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 

--- a/stubs/DecoratesOutput.php
+++ b/stubs/DecoratesOutput.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/stubs/DecoratesStyledOutput.php
+++ b/stubs/DecoratesStyledOutput.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;

--- a/stubs/StyledOutput.php
+++ b/stubs/StyledOutput.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Input;
+namespace Fidry\Console\Output;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;

--- a/tests/Application/Feature/BaseApplicationTest.php
+++ b/tests/Application/Feature/BaseApplicationTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Fidry\Console\Tests\Application\Fixture\BaseApplication;
 use Fidry\Console\Tests\Application\OutputAssertions;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/Fixture/ApplicationWithConfigurableIO.php
+++ b/tests/Application/Fixture/ApplicationWithConfigurableIO.php
@@ -15,7 +15,7 @@ namespace Fidry\Console\Tests\Application\Fixture;
 
 use Fidry\Console\Application\Application;
 use Fidry\Console\Application\ConfigurableIO;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Fidry\Console\Tests\Command\Fixture\SimpleCommand;
 use Fidry\Console\Tests\StatefulService;
 

--- a/tests/Application/Fixture/ApplicationWithLazyCommands.php
+++ b/tests/Application/Fixture/ApplicationWithLazyCommands.php
@@ -17,7 +17,7 @@ use Fidry\Console\Application\Application;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\Command\LazyCommand;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Fidry\Console\Tests\Command\Fixture\FakeCommand;
 
 final class ApplicationWithLazyCommands implements Application

--- a/tests/Application/Fixture/FailingCommand.php
+++ b/tests/Application/Fixture/FailingCommand.php
@@ -15,7 +15,7 @@ namespace Fidry\Console\Tests\Application\Fixture;
 
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use UnexpectedValueException;
 
 final class FailingCommand implements Command

--- a/tests/Command/Fixture/CommandAwareCommand.php
+++ b/tests/Command/Fixture/CommandAwareCommand.php
@@ -19,7 +19,7 @@ use Fidry\Console\Command\CommandAwareness;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\Command\InitializableCommand;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 final class CommandAwareCommand implements Command, CommandAware, InitializableCommand
 {

--- a/tests/Command/Fixture/CommandWithArgumentAndOption.php
+++ b/tests/Command/Fixture/CommandWithArgumentAndOption.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Tests\Command\Fixture;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use function sprintf;

--- a/tests/Command/Fixture/CommandWithHelpers.php
+++ b/tests/Command/Fixture/CommandWithHelpers.php
@@ -17,7 +17,7 @@ use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Helper\QuestionHelper;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;

--- a/tests/Command/Fixture/CommandWithService.php
+++ b/tests/Command/Fixture/CommandWithService.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Tests\Command\Fixture;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Fidry\Console\Tests\StatefulService;
 
 final class CommandWithService implements Command

--- a/tests/Command/Fixture/FakeCommand.php
+++ b/tests/Command/Fixture/FakeCommand.php
@@ -17,7 +17,7 @@ use DomainException;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 final class FakeCommand implements Command
 {

--- a/tests/Command/Fixture/FullLifeCycleCommand.php
+++ b/tests/Command/Fixture/FullLifeCycleCommand.php
@@ -20,7 +20,7 @@ use Fidry\Console\Command\InitializableCommand;
 use Fidry\Console\Command\InteractiveCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Helper\QuestionHelper;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use LogicException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Question\Question;

--- a/tests/Command/Fixture/SimpleCommand.php
+++ b/tests/Command/Fixture/SimpleCommand.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Tests\Command\Fixture;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 /**
  * Most basic command: only has a name & description and does not do anything

--- a/tests/Command/Fixture/SimpleLazyCommand.php
+++ b/tests/Command/Fixture/SimpleLazyCommand.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Tests\Command\Fixture;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\Command\LazyCommand;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use Fidry\Console\Tests\StatefulService;
 
 final class SimpleLazyCommand implements LazyCommand

--- a/tests/IO/DummyConsoleOutput.php
+++ b/tests/IO/DummyConsoleOutput.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\IO;
 
 use DomainException;
-use Fidry\Console\Input\DecoratesOutput;
+use Fidry\Console\Output\DecoratesOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/tests/IO/DummyStyledOutput.php
+++ b/tests/IO/DummyStyledOutput.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\IO;
 
 use Closure;
-use Fidry\Console\Input\StyledOutput;
-use Fidry\Console\Input\SymfonyStyledOutput;
+use Fidry\Console\Output\StyledOutput;
+use Fidry\Console\Output\SymfonyStyledOutput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/tests/IO/IOArgumentTest.php
+++ b/tests/IO/IOArgumentTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\IO;
 
 use Fidry\Console\Input\InvalidInputValueType;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,8 +22,8 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 /**
- * @covers \Fidry\Console\Input\IO
  * @covers \Fidry\Console\InputAssert
+ * @covers \Fidry\Console\IO
  *
  * @internal
  */

--- a/tests/IO/IOOptionsTest.php
+++ b/tests/IO/IOOptionsTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\IO;
 
 use Fidry\Console\Input\InvalidInputValueType;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
@@ -22,8 +22,8 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 /**
- * @covers \Fidry\Console\Input\IO
  * @covers \Fidry\Console\InputAssert
+ * @covers \Fidry\Console\IO
  *
  * @internal
  */

--- a/tests/IO/IOTest.php
+++ b/tests/IO/IOTest.php
@@ -15,8 +15,8 @@ namespace Fidry\Console\Tests\IO;
 
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
-use Fidry\Console\Input\IO;
-use Fidry\Console\Input\SymfonyStyledOutput;
+use Fidry\Console\IO;
+use Fidry\Console\Output\SymfonyStyledOutput;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -34,8 +34,8 @@ use Symfony\Component\Console\Output\NullOutput;
 use TypeError;
 
 /**
- * @covers \Fidry\Console\Input\IO
  * @covers \Fidry\Console\InputAssert
+ * @covers \Fidry\Console\IO
  *
  * @internal
  */

--- a/tests/IO/TypeAssertions.php
+++ b/tests/IO/TypeAssertions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\IO;
 
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Exception\InvalidArgumentException as ConsoleInvalidArgumentException;
 use function sprintf;

--- a/tests/Test/Fixture/PathCommand.php
+++ b/tests/Test/Fixture/PathCommand.php
@@ -16,7 +16,7 @@ namespace Fidry\Console\Tests\Test\Fixture;
 use Fidry\Console\Command\Command;
 use Fidry\Console\Command\Configuration;
 use Fidry\Console\ExitCode;
-use Fidry\Console\Input\IO;
+use Fidry\Console\IO;
 
 final class PathCommand implements Command
 {


### PR DESCRIPTION
- Move IO one namespace up (out of the `Input` namespace)
- Move all the output related classes to a `Output` namespace