### PR TITLE
chore: Remove infection logging to stdout

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,9 +6,6 @@
             "src"
         ]
     },
-    "logs": {
-        "text": "php://stderr"
-    },
     "tmpDir": "dist/infection",
     "mutators": {
         "@default": true,


### PR DESCRIPTION
There is already a logging done to the stdout via `--stdout`