### PR TITLE
tests: Fix the pipeline

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
             -   name: Check out repository code
                 uses: actions/checkout@v3
 
-            -   name: Setup PHP"
+            -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.3",
         "symfony/dependency-injection": "^5.4 || ^6.1",
-        "symfony/flex": "^2.2",
+        "symfony/flex": "^2.3",
         "symfony/framework-bundle": "^5.4 || ^6.1",
         "symfony/http-kernel": "^5.4 || ^6.1",
         "symfony/phpunit-bridge": "^4.4.47 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "webmozarts/strict-phpunit": "^7.3"
     },
     "conflict": {
-        "symfony/dependency-injection": "<5.4.0 || >=6.0.0,<6.1.0",
-        "symfony/framework-bundle": "<5.4.0 || >=6.0.0,<6.1.0",
-        "symfony/http-kernel": "<5.4.0 || >=6.0.0,<6.1.0"
+        "symfony/dependency-injection": "<5.4.0 || >=6.0.0 <6.1.0",
+        "symfony/framework-bundle": "<5.4.0 || >=6.0.0 <6.1.0",
+        "symfony/http-kernel": "<5.4.0 || >=6.0.0 <6.1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.3",
         "symfony/dependency-injection": "^5.4 || ^6.1",
-        "symfony/flex": "^1.19 || ^2.2",
+        "symfony/flex": "^2.2",
         "symfony/framework-bundle": "^5.4 || ^6.1",
         "symfony/http-kernel": "^5.4 || ^6.1",
         "symfony/phpunit-bridge": "^4.4.47 || ^5.4 || ^6.0",

--- a/tests/Command/Feature/CommandFullLifeCycleSupportTest.php
+++ b/tests/Command/Feature/CommandFullLifeCycleSupportTest.php
@@ -61,7 +61,7 @@ final class CommandFullLifeCycleSupportTest extends KernelTestCase
         $this->tester->setInputs(['username' => 'Jean']);
 
         $this->expectException(RuntimeException::class);
-        $this->expectErrorMessage('Not enough arguments (missing: "username")');
+        $this->expectExceptionMessage('Not enough arguments (missing: "username")');
 
         $this->tester->execute([], ['interactive' => false]);
     }


### PR DESCRIPTION
- Fix the lowest dep build by bumping the version of `symfony/flex`. Since it is used for dev only it has no impact for the consumer.
- Fix the composer.json CS.
- Fix the other failures which were related to PHPUnit deprecations.