### PR TITLE
chore: Fix the http_method_override deprecated setting

### DIFF
--- a/tests/Integration/services.yaml
+++ b/tests/Integration/services.yaml
@@ -1,6 +1,7 @@
 framework:
     secret: 'e6bd98c41c9f2868471cc94c7443c9d4'
     test: true
+    http_method_override: false
 
 services:
     _defaults:


### PR DESCRIPTION
Fix the following deprecation:

```
Since symfony/framework-bundle 6.1: Not setting the "framework.http_method_override" config option is deprecated. It will default to "false" in 7.0
```