### PR TITLE
chore: Exclude the compatibility layer from the coverage reports

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,6 +32,8 @@
         <exclude>
             <file>src/FidryConsoleBundle.php</file>
             <directory>src/DependencyInjection</directory>
+            <directory>src/Input/Compatibility</directory>
+            <directory>src/Output/Compatibility</directory>
         </exclude>
     </source>
 </phpunit>


### PR DESCRIPTION
It does not really make sense to include it unless combining the reports with the different version runs which is too cumbersome for the value it provides.