### PR TITLE
refactor: Move the Symfony classes to a Bridge namespace

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -68,7 +68,8 @@
         },
         "UnwrapArrayValues": {
             "ignore": [
-                "Fidry\\Console\\Application\\SymfonyApplication::getSymfonyCommands"
+                // The following should be caught by Psalm not unit tests.
+                "Fidry\\Console\\Bridge\\Application\\SymfonyApplication::getSymfonyCommands"
             ]
         }
     }

--- a/psalm.xml
+++ b/psalm.xml
@@ -40,7 +40,7 @@
     <issueHandlers>
         <DuplicateArrayKey>
             <errorLevel type="suppress">
-                <file name="src/Application/SymfonyApplication.php"/>
+                <file name="src/Bridge/Application/SymfonyApplication.php"/>
             </errorLevel>
         </DuplicateArrayKey>
 

--- a/src/Application/ApplicationRunner.php
+++ b/src/Application/ApplicationRunner.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Application;
 
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\IO;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Bridge/Application/SymfonyApplication.php
+++ b/src/Bridge/Application/SymfonyApplication.php
@@ -11,11 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Application;
+namespace Fidry\Console\Bridge\Application;
 
+use Fidry\Console\Application\Application;
+use Fidry\Console\Application\ConfigurableIO;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\Command\Command as FidryCommand;
 use Fidry\Console\Command\LazyCommand as FidryLazyCommand;
-use Fidry\Console\Command\SymfonyCommand;
 use Fidry\Console\IO;
 use LogicException;
 use Symfony\Component\Console\Application as BaseSymfonyApplication;
@@ -119,7 +121,7 @@ final class SymfonyApplication extends BaseSymfonyApplication
     }
 
     /**
-     * @return list<BaseSymfonyCommand>
+     * @return BaseSymfonyCommand[]
      */
     private function getSymfonyCommands(): array
     {

--- a/src/Bridge/Application/SymfonyApplication.php
+++ b/src/Bridge/Application/SymfonyApplication.php
@@ -121,7 +121,7 @@ final class SymfonyApplication extends BaseSymfonyApplication
     }
 
     /**
-     * @return BaseSymfonyCommand[]
+     * @return list<BaseSymfonyCommand>
      */
     private function getSymfonyCommands(): array
     {

--- a/src/Bridge/Command/ReversedSymfonyCommand.php
+++ b/src/Bridge/Command/ReversedSymfonyCommand.php
@@ -11,13 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Command;
+namespace Fidry\Console\Bridge\Command;
 
+use Fidry\Console\Command\Command;
+use Fidry\Console\Command\Configuration;
 use Fidry\Console\IO;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 /**
- * Bridge between a new Command API and a traditional Symfony console command.
+ * Implements a Fidry command based on a Symfony command.
  *
  * @private
  */

--- a/src/Bridge/Command/SymfonyCommand.php
+++ b/src/Bridge/Command/SymfonyCommand.php
@@ -11,8 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Fidry\Console\Command;
+namespace Fidry\Console\Bridge\Command;
 
+use Fidry\Console\Command\Command;
+use Fidry\Console\Command\CommandAware;
+use Fidry\Console\Command\CommandRegistry;
+use Fidry\Console\Command\InitializableCommand;
+use Fidry\Console\Command\InteractiveCommand;
 use Fidry\Console\IO;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;
@@ -20,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Bridge between a traditional Symfony console command and the new Command API.
+ * Implements a Symfony command based on a Fidry command.
  */
 final class SymfonyCommand extends BaseSymfonyCommand
 {

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Command;
 
+use Fidry\Console\Bridge\Command\ReversedSymfonyCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 

--- a/src/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Fidry\Console\DependencyInjection\Compiler;
 
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\Command\LazyCommand;
-use Fidry\Console\Command\SymfonyCommand;
 use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Test/AppTester.php
+++ b/src/Test/AppTester.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Test;
 
 use Fidry\Console\Application\Application as ConsoleApplication;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\DisplayNormalizer;
 use Symfony\Component\Console\Tester\ApplicationTester;
 

--- a/src/Test/CommandTester.php
+++ b/src/Test/CommandTester.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Test;
 
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\Command\Command;
-use Fidry\Console\Command\SymfonyCommand;
 use Fidry\Console\DisplayNormalizer;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester as SymfonyCommandTester;

--- a/tests/Application/Feature/ApplicationCatchingExceptionSupportTest.php
+++ b/tests/Application/Feature/ApplicationCatchingExceptionSupportTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\Tests\Application\Fixture\ApplicationThrowingException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/tests/Application/Feature/ApplicationSimpleConfigSupportTest.php
+++ b/tests/Application/Feature/ApplicationSimpleConfigSupportTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\Tests\Application\Fixture\SimpleApplication;
 use Fidry\Console\Tests\Application\OutputAssertions;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Application/Feature/ApplicationWithLazyCommandsTest.php
+++ b/tests/Application/Feature/ApplicationWithLazyCommandsTest.php
@@ -15,7 +15,7 @@ namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
 use Fidry\Console\Application\BaseApplication;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\Tests\Application\Fixture\ApplicationWithLazyCommands;
 use Fidry\Console\Tests\Application\OutputAssertions;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Application/Feature/BaseApplicationTest.php
+++ b/tests/Application/Feature/BaseApplicationTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\IO;
 use Fidry\Console\Tests\Application\Fixture\SimpleApplicationUsingBaseApplication;
 use Fidry\Console\Tests\Application\OutputAssertions;

--- a/tests/Application/Feature/IOConfigurationSupportTest.php
+++ b/tests/Application/Feature/IOConfigurationSupportTest.php
@@ -15,7 +15,7 @@ namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\Application;
 use Fidry\Console\Application\ApplicationRunner;
-use Fidry\Console\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Application\SymfonyApplication;
 use Fidry\Console\Tests\Application\Fixture\ApplicationWithConfigurableIO;
 use Fidry\Console\Tests\Application\Fixture\SimpleApplication;
 use Fidry\Console\Tests\StatefulService;

--- a/tests/Command/Feature/CommandArgumentsAndOptionsSupportTest.php
+++ b/tests/Command/Feature/CommandArgumentsAndOptionsSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Tests\Command\CommandAssertions;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Command/Feature/CommandAwarenessSupportTest.php
+++ b/tests/Command/Feature/CommandAwarenessSupportTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\Command\CommandAwareness;
-use Fidry\Console\Command\SymfonyCommand;
 use Fidry\Console\Tests\StatefulService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/tests/Command/Feature/CommandFullLifeCycleSupportTest.php
+++ b/tests/Command/Feature/CommandFullLifeCycleSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Tests\Command\CommandAssertions;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Command/Feature/CommandHelperInjectionSupportTest.php
+++ b/tests/Command/Feature/CommandHelperInjectionSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/Command/Feature/CommandLazinessSupportTest.php
+++ b/tests/Command/Feature/CommandLazinessSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Tests\StatefulService;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Command/Feature/CommandMetaDescriptionSupportTest.php
+++ b/tests/Command/Feature/CommandMetaDescriptionSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Tests\Command\CommandAssertions;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Command/Feature/CommandServiceInjectionSupportTest.php
+++ b/tests/Command/Feature/CommandServiceInjectionSupportTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Command\Feature;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\Tests\StatefulService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/tests/Test/SymfonyOutputAssertionsTest.php
+++ b/tests/Test/SymfonyOutputAssertionsTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Fidry\Console\Tests\Test;
 
-use Fidry\Console\Command\SymfonyCommand;
+use Fidry\Console\Bridge\Command\SymfonyCommand;
 use Fidry\Console\ExitCode;
 use Fidry\Console\Test\OutputAssertions;
 use Fidry\Console\Tests\Test\Fixture\PathCommand;


### PR DESCRIPTION
The current layout makes sense from the library consumer perspective, but often I need to touch the actual bridge between the Symfony native API and the library new API. In order to ease this task, I find helpful to move those classes under a common `Bridge` namespace.

Note that it's mostly private (or should be private) classes anyway so I do not expect to impact the consumers.