### PR TITLE
feat: Add a symfony command factory extension point

### DIFF
--- a/src/Application/ApplicationRunner.php
+++ b/src/Application/ApplicationRunner.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Fidry\Console\Application;
 
 use Fidry\Console\Bridge\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Command\BasicSymfonyCommandFactory;
+use Fidry\Console\Bridge\Command\SymfonyCommandFactory;
 use Fidry\Console\IO;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,9 +26,14 @@ final class ApplicationRunner
 {
     private SymfonyApplication $application;
 
-    public function __construct(Application $application)
-    {
-        $this->application = new SymfonyApplication($application);
+    public function __construct(
+        Application $application,
+        ?SymfonyCommandFactory $commandFactory = null,
+    ) {
+        $this->application = new SymfonyApplication(
+            $application,
+            $commandFactory ?? new BasicSymfonyCommandFactory(),
+        );
     }
 
     /**
@@ -41,9 +48,15 @@ final class ApplicationRunner
     public static function runApplication(
         Application $application,
         ?InputInterface $input = null,
-        ?OutputInterface $output = null
+        ?OutputInterface $output = null,
+        ?SymfonyCommandFactory $commandFactory = null,
     ): int {
-        return (new self($application))->run(
+        $runner = new self(
+            $application,
+            $commandFactory,
+        );
+
+        return $runner->run(
             new IO(
                 $input ?? new ArgvInput(),
                 $output ?? new ConsoleOutput(),

--- a/src/Bridge/Command/BasicSymfonyCommandFactory.php
+++ b/src/Bridge/Command/BasicSymfonyCommandFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Bridge\Command;
+
+use Fidry\Console\Command\Command as FidryCommand;
+use Fidry\Console\Command\LazyCommand as FidryLazyCommand;
+use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;
+use Symfony\Component\Console\Command\LazyCommand as SymfonyLazyCommand;
+
+final class BasicSymfonyCommandFactory implements SymfonyCommandFactory
+{
+    public function crateSymfonyCommand(FidryCommand $command): BaseSymfonyCommand
+    {
+        return $command instanceof FidryLazyCommand
+            ? new SymfonyLazyCommand(
+                $command::getName(),
+                [],
+                $command::getDescription(),
+                false,
+                static fn () => new SymfonyCommand($command),
+                true,
+            )
+            : new SymfonyCommand($command);
+    }
+}

--- a/src/Bridge/Command/SymfonyCommandFactory.php
+++ b/src/Bridge/Command/SymfonyCommandFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Bridge\Command;
+
+use Fidry\Console\Command\Command as FidryCommand;
+use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;
+
+interface SymfonyCommandFactory
+{
+    public function crateSymfonyCommand(FidryCommand $command): BaseSymfonyCommand;
+}

--- a/src/Test/AppTester.php
+++ b/src/Test/AppTester.php
@@ -15,6 +15,8 @@ namespace Fidry\Console\Test;
 
 use Fidry\Console\Application\Application as ConsoleApplication;
 use Fidry\Console\Bridge\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Command\BasicSymfonyCommandFactory;
+use Fidry\Console\Bridge\Command\SymfonyCommandFactory;
 use Fidry\Console\DisplayNormalizer;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
@@ -23,10 +25,15 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 final class AppTester extends ApplicationTester
 {
-    public static function fromConsoleApp(ConsoleApplication $application): self
-    {
+    public static function fromConsoleApp(
+        ConsoleApplication $application,
+        SymfonyCommandFactory $commandFactory = new BasicSymfonyCommandFactory(),
+    ): self {
         return new self(
-            new SymfonyApplication($application),
+            new SymfonyApplication(
+                $application,
+                $commandFactory,
+            ),
         );
     }
 

--- a/tests/Application/ApplicationRunnerTest.php
+++ b/tests/Application/ApplicationRunnerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Tests\Application;
+
+use DomainException;
+use Fidry\Console\Application\ApplicationRunner;
+use Fidry\Console\Tests\Application\Fixture\FakeSymfonyCommandFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ApplicationRunner::class)]
+final class ApplicationRunnerTest extends TestCase
+{
+    public function test_it_uses_the_command_factory_given(): void
+    {
+        $runner = new ApplicationRunner(
+            new DummyApplication(),
+            new FakeSymfonyCommandFactory(),
+        );
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('Should not be called.');
+
+        $runner->run();
+    }
+}

--- a/tests/Application/DummyApplication.php
+++ b/tests/Application/DummyApplication.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Tests\Application;
+
+use Fidry\Console\Application\BaseApplication;
+use Fidry\Console\Tests\Command\Fixture\SimpleCommand;
+
+final class DummyApplication extends BaseApplication
+{
+    public function getName(): string
+    {
+        return 'DummyApp';
+    }
+
+    public function getVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    public function getCommands(): array
+    {
+        return [
+            new SimpleCommand(),
+        ];
+    }
+
+    public function getDefaultCommand(): string
+    {
+        return 'app:foo';
+    }
+
+    public function isAutoExitEnabled(): bool
+    {
+        return false;
+    }
+
+    public function areExceptionsCaught(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Application/Feature/BaseApplicationTest.php
+++ b/tests/Application/Feature/BaseApplicationTest.php
@@ -15,6 +15,7 @@ namespace Fidry\Console\Tests\Application\Feature;
 
 use Fidry\Console\Application\ApplicationRunner;
 use Fidry\Console\Bridge\Application\SymfonyApplication;
+use Fidry\Console\Bridge\Command\BasicSymfonyCommandFactory;
 use Fidry\Console\IO;
 use Fidry\Console\Tests\Application\Fixture\SimpleApplicationUsingBaseApplication;
 use Fidry\Console\Tests\Application\OutputAssertions;
@@ -74,7 +75,10 @@ final class BaseApplicationTest extends TestCase
         $input = new StringInput('list');
         $output = new BufferedOutput();
 
-        $runner = new ApplicationRunner(new SimpleApplicationUsingBaseApplication());
+        $runner = new ApplicationRunner(
+            new SimpleApplicationUsingBaseApplication(),
+            new BasicSymfonyCommandFactory(),
+        );
 
         $runner->run(
             new IO($input, $output),
@@ -91,7 +95,10 @@ final class BaseApplicationTest extends TestCase
         $input = new StringInput('--version');
         $output = new BufferedOutput();
 
-        $runner = new ApplicationRunner(new SimpleApplicationUsingBaseApplication());
+        $runner = new ApplicationRunner(
+            new SimpleApplicationUsingBaseApplication(),
+            new BasicSymfonyCommandFactory(),
+        );
 
         $runner->run(
             new IO($input, $output),

--- a/tests/Application/Fixture/FakeSymfonyCommandFactory.php
+++ b/tests/Application/Fixture/FakeSymfonyCommandFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Tests\Application\Fixture;
+
+use DomainException;
+use Fidry\Console\Bridge\Command\SymfonyCommandFactory;
+use Fidry\Console\Command\Command as FidryCommand;
+use Symfony\Component\Console\Command\Command as BaseSymfonyCommand;
+
+final class FakeSymfonyCommandFactory implements SymfonyCommandFactory
+{
+    public function crateSymfonyCommand(FidryCommand $command): BaseSymfonyCommand
+    {
+        throw new DomainException('Should not be called.');
+    }
+}

--- a/tests/Bridge/Command/BasicSymfonyCommandFactoryTest.php
+++ b/tests/Bridge/Command/BasicSymfonyCommandFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Fidry\Console package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Console\Tests\Bridge\Command;
+
+use Fidry\Console\Bridge\Command\BasicSymfonyCommandFactory;
+use Fidry\Console\Bridge\Command\SymfonyCommand as SymfonyBridgeCommand;
+use Fidry\Console\Command\Command as FidryCommand;
+use Fidry\Console\Tests\Command\Fixture\SimpleCommand;
+use Fidry\Console\Tests\Command\Fixture\SimpleLazyCommand;
+use Fidry\Console\Tests\StatefulService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Command\LazyCommand as SymfonyLazyCommand;
+
+#[CoversClass(BasicSymfonyCommandFactory::class)]
+final class BasicSymfonyCommandFactoryTest extends TestCase
+{
+    #[DataProvider('commandProvider')]
+    public function test_it_can_create_a_symfony_command_from_a_fidry_command(
+        FidryCommand $command,
+        SymfonyCommand $expected,
+    ): void {
+        $actual = (new BasicSymfonyCommandFactory())->crateSymfonyCommand($command);
+
+        self::assertEquals($expected, $actual);
+    }
+
+    public static function commandProvider(): iterable
+    {
+        yield 'standard command' => [
+            new SimpleCommand(),
+            new SymfonyBridgeCommand(
+                new SimpleCommand(),
+            ),
+        ];
+
+        yield 'lazy command' => [
+            new SimpleLazyCommand(new StatefulService()),
+            new SymfonyLazyCommand(
+                'app:lazy',
+                [],
+                'lazy command description',
+                false,
+                static fn () => new SymfonyBridgeCommand(
+                    new SimpleLazyCommand(new StatefulService()),
+                ),
+                true,
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
In the current form internally this is primarily a refactoring to extract code from `SymfonyApplication`. However while doing it, I realised it is probably better to have it as a proper extension point although I highly doubt anyone is going to use it.